### PR TITLE
Add :noautocmd for executing yank mapping

### DIFF
--- a/plugin/visualstar.vim
+++ b/plugin/visualstar.vim
@@ -16,7 +16,7 @@ function! s:search(type, g)
   let s:count = v:count1 . a:type
   let reg = '"'
   let [save_reg, save_type] = [getreg(reg), getregtype(reg)]
-  normal! gv""y
+  noautocmd normal! gv""y
   let text = @"
   call setreg(reg, save_reg, save_type)
 


### PR DESCRIPTION
I'm using vim-visualstar with [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank). I noticed that `*` on visual mode highlighted the search text as yanked. This was because `normal! y` triggered `TextYankPost` autocmd event and vim-highlightedyank hooked the event.

To prevent the unexpected autocmd event, I prefixed `:noautocmd` at `:normal!` command.